### PR TITLE
DEV: Add plugin label metadata

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -5,6 +5,7 @@
 # version: 1.0
 # authors: Discourse
 # url: https://github.com/discourse/discourse-cdn-experiment
+# label: experiment
 
 enabled_site_setting :cdn_experiment_enabled
 


### PR DESCRIPTION
Since https://github.com/discourse/discourse/commit/c58cd697d2361b178b8a12593e0193e11496a733
we can add a label to plugins to show in the plugin list.

Adding experimental label to this plugin.
